### PR TITLE
Use Long

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ repositories {
 
 dependencies {
 	testCompile 'junit:junit:4.12'
-	compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
 }
 
 ext {

--- a/src/main/java/com/github/yuchi/semver/Range.java
+++ b/src/main/java/com/github/yuchi/semver/Range.java
@@ -1,6 +1,5 @@
 package com.github.yuchi.semver;
 
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -282,14 +281,14 @@ public class Range {
 			}
 			else if (isX(toMinor)) {
 				sb.append("<");
-				sb.append(Integer.parseInt(toMajor) + 1);
+				sb.append(Long.parseLong(toMajor) + 1);
 				sb.append(".0.0");
 			}
 			else if (isX(toPatch)) {
 				sb.append("<");
 				sb.append(toMajor);
 				sb.append(".");
-				sb.append(Integer.parseInt(toMinor) + 1);
+				sb.append(Long.parseLong(toMinor) + 1);
 				sb.append(".0");
 			}
 			else if ((toPR != null) && !toPR.isEmpty()) {
@@ -347,7 +346,7 @@ public class Range {
 				sb.append(">=");
 				sb.append(major);
 				sb.append(".0.0 <");
-				sb.append(Integer.parseInt(major) + 1);
+				sb.append(Long.parseLong(major) + 1);
 				sb.append(".0.0");
 			}
 			else if (isX(patch)) {
@@ -359,7 +358,7 @@ public class Range {
 					sb.append(".0 <"); // SPACE!
 					sb.append(major);
 					sb.append(".");
-					sb.append(Integer.parseInt(minor) + 1);
+					sb.append(Long.parseLong(minor) + 1);
 					sb.append(".0");
 				}
 				else {
@@ -368,7 +367,7 @@ public class Range {
 					sb.append(".");
 					sb.append(minor);
 					sb.append(".0 <");
-					sb.append(Integer.parseInt(minor) + 1);
+					sb.append(Long.parseLong(minor) + 1);
 					sb.append(".0.0");
 				}
 			}
@@ -398,17 +397,17 @@ public class Range {
 						sb.append(".");
 						sb.append(minor);
 						sb.append(".");
-						sb.append(Integer.parseInt(patch) + 1);
+						sb.append(Long.parseLong(patch) + 1);
 					}
 					else {
 						sb.append(major);
 						sb.append(".");
-						sb.append(Integer.parseInt(minor) + 1);
+						sb.append(Long.parseLong(minor) + 1);
 						sb.append(".0");
 					}
 				}
 				else {
-					sb.append(Integer.parseInt(major) + 1);
+					sb.append(Long.parseLong(major) + 1);
 					sb.append(".0.0");
 				}
 			}
@@ -435,7 +434,7 @@ public class Range {
 				sb.append(">=");
 				sb.append(major);
 				sb.append(".0.0 <"); // SPACE!
-				sb.append(Integer.parseInt(major) + 1);
+				sb.append(Long.parseLong(major) + 1);
 				sb.append(".0.0");
 			}
 			else if (isX(patch)) {
@@ -447,7 +446,7 @@ public class Range {
 				sb.append(".0 <"); // SPACE!
 				sb.append(major);
 				sb.append(".");
-				sb.append(Integer.parseInt(minor) + 1);
+				sb.append(Long.parseLong(minor) + 1);
 				sb.append(".0");
 			}
 			else {
@@ -469,7 +468,7 @@ public class Range {
 				sb.append(" <");
 				sb.append(major);
 				sb.append(".");
-				sb.append(Integer.parseInt(minor) + 1);
+				sb.append(Long.parseLong(minor) + 1);
 				sb.append(".0");
 			}
 
@@ -525,12 +524,12 @@ public class Range {
 					gtlt = ">=";
 
 					if (xMinor) {
-						major = String.valueOf(Integer.parseInt(major) + 1);
+						major = String.valueOf(Long.parseLong(major) + 1);
 						minor = "0";
 						patch = "0";
 					}
 					else if (xPatch) {
-						minor = String.valueOf(Integer.parseInt(minor) + 1);
+						minor = String.valueOf(Long.parseLong(minor) + 1);
 						patch = "0";
 					}
 				}
@@ -541,10 +540,10 @@ public class Range {
 					gtlt = "<";
 
 					if (xMinor) {
-						major = String.valueOf(Integer.parseInt(major) + 1);
+						major = String.valueOf(Long.parseLong(major) + 1);
 					}
 					else {
-						minor = String.valueOf(Integer.parseInt(minor) + 1);
+						minor = String.valueOf(Long.parseLong(minor) + 1);
 					}
 				}
 
@@ -559,7 +558,7 @@ public class Range {
 				sb.append(">=");
 				sb.append(major);
 				sb.append(".0.0 <");
-				sb.append(Integer.parseInt(major) + 1);
+				sb.append(Long.parseLong(major) + 1);
 				sb.append(".0.0");
 			}
 			else if (xPatch) {
@@ -570,7 +569,7 @@ public class Range {
 				sb.append(".0 <");
 				sb.append(major);
 				sb.append(".");
-				sb.append(Integer.parseInt(minor) + 1);
+				sb.append(Long.parseLong(minor) + 1);
 				sb.append(".0");
 			}
 			else {

--- a/src/main/java/com/github/yuchi/semver/Version.java
+++ b/src/main/java/com/github/yuchi/semver/Version.java
@@ -46,21 +46,21 @@ public class Version implements Comparable<Version> {
 			throw new IllegalArgumentException("Invalid Version: " + raw);
 		}
 
-		this.major = Integer.parseInt(m.group(1));
+		this.major = Long.parseLong(m.group(1));
 
-		if ((this.major < 0) || (this.major == Integer.MAX_VALUE)) {
+		if ((this.major < 0) || (this.major == Long.MAX_VALUE)) {
 			throw new IllegalArgumentException("Invalid Major Version");
 		}
 
-		this.minor = Integer.parseInt(m.group(2));
+		this.minor = Long.parseLong(m.group(2));
 
-		if ((this.minor < 0) || (this.minor == Integer.MAX_VALUE)) {
+		if ((this.minor < 0) || (this.minor == Long.MAX_VALUE)) {
 			throw new IllegalArgumentException("Invalid Minor Version");
 		}
 
-		this.patch = Integer.parseInt(m.group(3));
+		this.patch = Long.parseLong(m.group(3));
 
-		if ((this.patch < 0) || (this.patch == Integer.MAX_VALUE)) {
+		if ((this.patch < 0) || (this.patch == Long.MAX_VALUE)) {
 			throw new IllegalArgumentException("Invalid Patch Version");
 		}
 
@@ -78,7 +78,7 @@ public class Version implements Comparable<Version> {
 				String part = parts[i];
 
 				if (Constants.NUMERIC.matches(part)) {
-					this.prerelease[i] = Integer.parseInt(part);
+					this.prerelease[i] = Long.parseLong(part);
 				}
 				else {
 					this.prerelease[i] = part;
@@ -119,15 +119,15 @@ public class Version implements Comparable<Version> {
 		this.version = sb.toString();
 	}
 
-	public int getMajor() {
+	public long getMajor() {
 		return this.major;
 	}
 
-	public int getMinor() {
+	public long getMinor() {
 		return this.minor;
 	}
 
-	public int getPatch() {
+	public long getPatch() {
 		return this.patch;
 	}
 
@@ -232,11 +232,11 @@ public class Version implements Comparable<Version> {
 	}
 
 	protected static int compareIdentifiers(Object a, Object b) {
-		boolean anumeric = a instanceof Integer;
-		boolean bnumeric = b instanceof Integer;
+		boolean anumeric = a instanceof Long;
+		boolean bnumeric = b instanceof Long;
 
 		if (anumeric && bnumeric) {
-			return ((Integer)a).compareTo((Integer)b);
+			return ((Long)a).compareTo((Long)b);
 		}
 		else if (!anumeric && !bnumeric) {
 			return ((String)a).compareTo((String)b);
@@ -249,9 +249,9 @@ public class Version implements Comparable<Version> {
 		}
 	}
 
-	protected final int major;
-	protected final int minor;
-	protected final int patch;
+	protected final long major;
+	protected final long minor;
+	protected final long patch;
 	protected final Object[] prerelease;
 	protected final String[] build;
 	protected final String raw;

--- a/src/test/java/com/github/yuchi/semver/ValidVersionStrings.java
+++ b/src/test/java/com/github/yuchi/semver/ValidVersionStrings.java
@@ -1,0 +1,40 @@
+package com.github.yuchi.semver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ValidVersionStrings {
+
+    protected String version;
+
+    @Test
+    public void valid() {
+        new Version(this.version);
+    }
+
+    public ValidVersionStrings(String version) {
+        this.version = version;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> getParameters() {
+        return Arrays.asList(new Object[][] {
+                {"1.2.3"},
+                {"1000000000000.2000000000000.30000000000000"},
+                {"1.2.3-alpha"},
+                {"1.2.3-alpha.1234567890"},
+                {"1.2.3-beta.1234567890123"},
+                {"1.2.3-4.5.6"},
+                {"1.2.3-x.4.y.5.z"},
+                {"1.2.3-alpha+1"},
+                {"1.2.3-beta+1234567890123"},
+                {"1.2.3-gamma+x.y.z.1234567890"},
+                {"1.2.3+1234567890123"}
+        });
+    }
+}


### PR DESCRIPTION
For this issue https://github.com/yuchi/java-npm-semver/issues/2

The solution might not be 100%; yet this should work for great majority. For extreme edge cases where version strings contain a long series of digits (particularly in patch), we can later patch the code to have them represented in String should such need arises.